### PR TITLE
docs: 📝 Add commit message instructions

### DIFF
--- a/.copilot-commit-message-instructions.md
+++ b/.copilot-commit-message-instructions.md
@@ -1,0 +1,89 @@
+# Commit Message Instructions
+
+- Use conventional commit message format.
+- The commit message should have a `short description` (50 characters or less) followed by a blank line and then a `description`.
+- The `short description` should be in the format: `<type>(<scope>):<icon> <summary>`
+  - `type`: The type of change (e.g., feat, fix, docs, style, refactor, test, chore).
+    - `feat`: ✨ A new feature. (Hint: There should be code files involved!)
+    - `fix`: 🐛 A bug fix
+    - `docs`: 📝 Documentation only changes
+    - `style`: 💄 Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
+    - `refactor`: ♻️ A code change that neither fixes a bug nor adds a feature
+    - `test`: ✅ Adding missing tests or correcting existing tests
+    - `chore`: 🔧 Changes to the build process or auxiliary tools and libraries such as documentation generation
+    - `perf`: ⚡️ A code change that improves performance
+    - `ci`: 👷 Changes to CI configuration files and scripts
+    - `build`: 🏗️ Changes that affect the build system or external dependencies
+    - `revert`: ⏪ Reverts a previous commit
+    - `wip`: 🚧 Work in progress
+    - `security`: 🔒 Security-related changes
+    - `i18n`: 🌐 Internationalization and localization
+    - `a11y`: ♿ Accessibility improvements
+    - `ux`: 🎨 User experience improvements
+    - `ui`: 🖌️ User interface changes
+    - `config`: 🔧 Configuration file changes
+    - `deps`: 📦 Dependency updates
+    - `infra`: 🌐 Infrastructure changes
+    - `init`: 🎉 Initial commit
+    - `analytics`: 📈 Analytics or tracking code
+    - `seo`: 🔍 SEO improvements
+    - `legal`: ⚖️ Licensing or legal changes
+    - `typo`: ✏️ Typo fixes
+    - `comment`: 💬 Adding or updating comments in the code
+    - `example`: 💡 Adding or updating examples
+    - `mock`: 🤖 Adding or updating mocks
+    - `hotfix`: 🚑 Critical hotfix
+    - `merge`: 🔀 Merging branches
+    - `cleanup`: 🧹 Code cleanup
+    - `deprecate`: 🗑️ Deprecating code or features
+    - `move`: 🚚 Moving or renaming files
+    - `rename`: ✏️ Renaming files or variables
+    - `split`: ✂️ Splitting files or functions
+    - `combine`: 🧬 Combining files or functions
+    - `add`: ➕ Adding files, features or content
+    - `remove`: ➖ Removing files, features or content
+    - `update`: ⬆️ Updating files, features or content
+    - `downgrade`: ⬇️ Downgrading files, features or content
+    - `patch`: 🩹 Applying patches
+    - `optimize`: 🛠️ Optimizing code
+
+  - `scope`: The scope of the change (e.g., component or file name). Include this if the change is specific to a particular part of the codebase.
+
+- `summary`: A brief summary of the change.
+
+- The `description` should provide additional context and details about the change. Try to keep it short and concise, but it can be longer than the `short description`. It should:
+  - Explain why the change was made.
+  - Describe what is being used and why.
+  - Include any relevant information that might be useful for understanding the change in the future.
+  - Reference any related issues or pull requests at the end of the long description.
+- If the commit fixes an issue or task, include `Close #<issue-number>` at the end of the long description.
+- If the commit introduces a breaking change, include `BREAKING CHANGE: <description of the breaking change>` at the end of the `description`.
+
+## Example
+
+### Commit Message Example
+
+```
+feat(auth): ✨ Add user authentication
+
+Added user authentication using JWT. This includes login, registration, and token verification endpoints.
+
+- Implemented JWT-based authentication.
+- Added login and registration endpoints.
+- Added middleware for token verification.
+
+Fixes #123
+```
+
+### Breaking Change Example
+
+```
+refactor(api): ♻️ Update API endpoints
+
+Refactored the API endpoints to follow RESTful conventions. This change affects all existing API calls.
+
+- Updated endpoint URLs to follow RESTful conventions.
+- Modified request and response formats.
+
+BREAKING CHANGE: All existing API calls need to be updated to the new endpoint URLs.
+```


### PR DESCRIPTION
Added guidelines for writing commit messages following the conventional format. This includes types, scopes, and examples to ensure consistency across the repository.